### PR TITLE
add -dev suffix to dev profiles

### DIFF
--- a/Dockerfile.backend.dev
+++ b/Dockerfile.backend.dev
@@ -1,15 +1,13 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.19
 USER 0
 ENV PROJECT_DIR=/backend \
-    GO111MODULE=on \
     CGO_ENABLED=0
 
 WORKDIR /backend
 RUN mkdir "/build"
 
 COPY . .
-RUN go get github.com/githubnemo/CompileDaemon
-RUN go install github.com/githubnemo/CompileDaemon
+RUN go install github.com/githubnemo/CompileDaemon@latest
 RUN make prep GO=go
 
 ENTRYPOINT $HOME/go/bin/CompileDaemon -build="go build -buildvcs=false -o /build/pbackend ./cmd/pbackend" -command="/build/pbackend api"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This repo helps rolling up the provisioning application, including frontend and 
 
 ```sh
 $ git clone https://github.com/RHEnVision/provisioning-compose.git
+$ git submodule init
+$ git submodule update
 ```
+
 After cloning, the folder structure should be:
 ```
    ├── provisioning-compose
@@ -16,13 +19,24 @@ After cloning, the folder structure should be:
    └── 
 ```
 
+Before use, some images are currently from private quay.io repositories so make sure to login via `docker login quay.io` or `podman login quay.io`.
+
 Run 
+
 ```sh
 $ COMPOSE_PROFILES=migrate,backend docker compose up 
-# Alternatively, with podman:
-$ COMPOSE_PROFILES=migrate,backend podman-compose up
 ```
+
+Alternatively, with podman:
+
+```
+pip3 install podman-compose
+$ podman-compose --profile backend up
+```
+
 This command also migrates data to postgres db, using the `migrate` profile.
+
+Make sure to use podman-compose 1.0.7 or newer for profiles feature, install development version if not available yet (as of Summer 2023).
 
 ### Profiles
 A compose profile allows you to run a subset of containers. When no profile is given, 
@@ -30,17 +44,20 @@ the provisioning backend, postgres and redis will run by default.
 
 Currently there are a few profiles:
 - migrate: migrate provisioning backend, terminates after migration
-- backend: running the provisioning backend, with postgres and redis
 - kafka: run kafka with zookeeper, register topics
-- frontend: run local provisioning frontend
 - sources: run latest sources service image from quay
 - sources-dev: run local sources with postgres db, on first use notice that you will need to run `/script/sources.seed.sh` for seeding your local sources data.
+- backend: running the provisioning backend, with postgres and redis from the official image
+- backend-dev: running the provisioning backend, with postgres and redis from git
+- frontend-dev: run local provisioning frontend
 
 For example, in order to run local sources, kafka, backend and frontend profiles, run
+
 ```sh
-# using docker
 $ COMPOSE_PROFILES=frontend,backend,kafka,sources-dev docker compose up 
 ```
+
+Multtiple compose profiles are not supported on podman yet.
 
 ### Custom configuration
  The `.env` files, [backend.env](/backend.env) and [sources.env](/sources.env) have all the minimum required env variables, if some custom variables are needed you are advised to rename the file and consume it in `compose.yml`

--- a/backend.env
+++ b/backend.env
@@ -1,10 +1,11 @@
 # Minimum required variables for compose file
 # This file is used for local development and testing
 # Edit this file to match your environment and rename it for safety
+# WARNING: This file is not evaluated through shell!
 
-KAFKA_BROKERS="kafka:29092"
-KAFKA_ENABLED="true"
-REST_ENDPOINTS_SOURCES_URL="http://sources:8131/api/sources/v3.1"
-DATABASE_PASSWORD="postgres"
-DATABASE_HOST='backend-db'
-APP_CACHE_REDIS_HOST='redis'
+KAFKA_BROKERS=kafka:29092
+KAFKA_ENABLED=true
+REST_ENDPOINTS_SOURCES_URL=http://sources:8131/api/sources/v3.1
+DATABASE_PASSWORD=postgres
+DATABASE_HOST=backend-db
+APP_CACHE_REDIS_HOST=redis

--- a/compose.yml
+++ b/compose.yml
@@ -5,6 +5,7 @@ services:
     image: docker.io/postgres:13.1
     profiles:
       - backend
+      - backend-dev
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 2s
@@ -22,9 +23,10 @@ services:
   redis:
     image: docker.io/redis:latest
     profiles:
-      - "redis"
-      - "sources"
-      - "backend"
+      - redis
+      - sources
+      - backend
+      - backend-dev
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 2s
@@ -99,10 +101,29 @@ services:
       - zookeeper
   
   backend:
-    env_file:
-      - backend.env
     profiles:
       - backend
+    env_file:
+      - backend.env
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      backend-db:
+        condition: service_healthy
+      init-kafka:
+        condition: service_completed_successfully
+    image: quay.io/cloudservices/provisioning-backend:latest
+    ports:
+      - ${APP_PORT:-8000}:${APP_PORT:-8000}
+      - ${PROMETHEUS_PORT:-9000}:${PROMETHEUS_PORT:-9000}
+    volumes:
+      - ./backend/:/backend
+
+  backend-dev:
+    profiles:
+      - backend-dev
+    env_file:
+      - backend.env
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -132,9 +153,9 @@ services:
         condition: service_healthy
     entrypoint: ["go","run","./cmd/pbackend", "migrate"]
 
-  frontend:
+  frontend-dev:
     profiles:
-      - frontend
+      - frontend-dev
     environment:
       - PROV_API_HOST=backend
       - WATCHPACK_POLLING=true
@@ -146,7 +167,7 @@ services:
     ports: 
       - 1337:1337
     depends_on:
-    - backend
+      - backend-dev
     entrypoint: [npm,run,start]
 
   sources:

--- a/sources.env
+++ b/sources.env
@@ -1,6 +1,7 @@
 # Minimum required variables for compose file
 # This file is used for local development and testing
 # It is not used for production deployment
+# WARNING: This file is not evaluated through shell!
 
 PORT=8131
 METRICS_PORT=9131
@@ -12,6 +13,5 @@ DATABASE_PASSWORD=postgres
 BYPASS_RBAC=true
 REDIS_CACHE_HOST=redis
 REDIS_CACHE_PORT=6379
-# used in seeding script
 SOURCES_API_HOST=http://sources
 SOURCES_API_PORT=$PORT


### PR DESCRIPTION
This renames "backend" and "frontend" profiles to "xxx-dev" as these really are development variants. I want to use the official images instead for my own use, this change adds "backend" only though.

Fixed couple of issues I encountered, env files are not evaluated therefore quotes are unwanted (backend service was failing with `"true" is not valid boolean`. 

I also fixed the "compile daemon" thing it was not installing at all due to old instructions in their README.

Also slightly updated and improved this repo README. Added submodules initialization.

Thanks.