### PR TITLE
fix notifications seeder dockerfile regression

### DIFF
--- a/notifications_seed/Dockerfile.notifications.seed
+++ b/notifications_seed/Dockerfile.notifications.seed
@@ -2,6 +2,6 @@ FROM registry.redhat.io/rhel9/python-39
 USER 0
 WORKDIR /notification_seed
 COPY ./notifications_seed/notifications.seed.py .
-COPY ./notifications-backend/backend/helpers/helpers.py .
+COPY ./notifications/backend/helpers/helpers.py .
 RUN pip3 install requests
 ENTRYPOINT [ "python3", "notifications.seed.py" ]


### PR DESCRIPTION
The notifications submodule was renamed, the dockerfile for the seeder needs an update.