### PR TITLE
feat: add image-builder-frontend profile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "notifications"]
 	path = notifications
 	url = https://github.com/RedHatInsights/notifications-backend.git
+[submodule "image-builder-frontend"]
+	path = image-builder-frontend
+	url = https://github.com/RedHatInsights/image-builder-frontend.git

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ After cloning, the folder structure should be:
    │   ├── frontend
    │   ├── notifications
    │   ├── sources-api-go
+   │   ├── image-builder-frontend   
    └── 
 ```
 
@@ -84,6 +85,7 @@ Profiles:
 - frontend-dev: run local provisioning frontend
 - notifications: running local notification-backend service
 - notifications-init: seeds the required provisioning data, required for the first notifications use.
+- image-builder-frontend: run local frontend (federated mode) and local image-builder frontend
 
 
 For example, in order to run local sources, kafka, local backend and frontend profiles, run
@@ -93,6 +95,12 @@ For example, in order to run local sources, kafka, local backend and frontend pr
  ### Notifications local setup
  See notifications [section](/notifications_seed/README.md)
 
+### Image builder
+[Image builder](https://github.com/RedHatInsights/image-builder-frontend) consumes provisioning application as a federated module, for adding the launch wizard component.
+Following this dependency, a local dev environment containing both apps is required.
+The profile `image-builder-frontend` runs provisioning in a static federated mode, and image-builder-frontend
+in beta-stage, both with live-reload capabilities.
+
 ### Connecting to Kafka
 
 Kafka advertises the connection (hostname and port) during session negotiation, therefore, it is necessary to change host resolution configuration in a way that "kafka" hostname resolves to the host that is hosting kafka containers. Typically:
@@ -101,6 +109,7 @@ Kafka advertises the connection (hostname and port) during session negotiation, 
 	127.0.0.1 kafka
 
 Change it accordingly if you running podman on a remote machine. The symptoms are that application (backend) is unable to connect to `kafka:9092` or `kafka:29092`.
+
 
 ### Live reloading for dev
 

--- a/compose.yml
+++ b/compose.yml
@@ -276,3 +276,31 @@ services:
     depends_on:
       notifications-backend:
         condition: service_healthy
+  image-builder-frontend:
+    profiles:
+      - "image-builder-frontend"
+    build:
+      context: ./image-builder-frontend
+      dockerfile: ./distribution/Dockerfile
+    environment:
+      - LOCAL_API=provisioning:8003~http~frontend-static
+    depends_on:
+      - frontend-static
+    volumes:
+      - ./image-builder-frontend/:/usr/src/app
+    ports:
+      - ${EXPOSED_IMAGE_BUILDER_PORT:-1337}:${IMAGE_BUILDER_PORT:-1337}
+    entrypoint: ["npm", "run", "stage-beta"]
+  frontend-static:
+    profiles:
+      - "image-builder-frontend"
+    environment:
+      - BETA=true
+    build:
+      context: ./frontend
+      dockerfile: ../Dockerfile.frontend.dev
+    volumes:
+      - ./frontend/:/frontend
+    entrypoint: ["npm", "run", "start:federated"]
+    ports: 
+      - ${EXPOSED_FRONTEND_STATIC_PORT:-8003}:${FRONTEND_STATIC_PORT:-8003}


### PR DESCRIPTION
[Image builder](https://github.com/RedHatInsights/image-builder-frontend) consumes provisioning application as a federated module, for adding the launch wizard component.
Following this dependency, a local dev environment containing both apps is required.

This PR adds the `image-builder-frontend` profile, which runs containerized image-builder app and provisioning app in a static federated mode,  both in beta-stage, with dev features, like live-reload capabilities.