### PR TITLE
Speed up Go compilation time

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -142,6 +142,8 @@ services:
       - ${EXPOSED_PROMETHEUS_PORT:-9000}:${PROMETHEUS_PORT:-9000}
     volumes:
       - ./backend/:/backend
+      - ${DATA_DIR:-./data}/go-cache:/opt/app-root/src/.cache/go-build
+      - ${DATA_DIR:-./data}/go-path:/opt/app-root/src/go
 
   frontend-dev:
     profiles:

--- a/prepare-podman.sh
+++ b/prepare-podman.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 podman unshare rm -rf ./data/*
-mkdir -p ./data/{redis,pg-backend,pg-sources,pg-notifications,zookeeper,kafka}
+mkdir -p ./data/{redis,pg-backend,pg-sources,pg-notifications,zookeeper,kafka,go-cache,go-path}
 podman unshare chown -R $(id -u):$(id -g) ./data/kafka ./data/zookeeper


### PR DESCRIPTION
This should speed up compilation time for "auto reloading" containers. Not sure how permissions will work across more containers tho - it might fail (Go might report permission error during compilation).

We still might consider having just one container for all three services by implementing multiple arguments.